### PR TITLE
feat: :hammer: implement "IN" and "NOT IN" in text custom fields

### DIFF
--- a/classes/condition_base.php
+++ b/classes/condition_base.php
@@ -101,6 +101,16 @@ abstract class condition_base {
     public const TEXT_IS_NOT_EQUAL_TO = 8;
 
     /**
+     * Value for operator text is in array
+     */
+    public const TEXT_IN = 9;
+
+    /**
+     * Value for operator text is not in array
+     */
+    public const TEXT_NOT_IN = 10;
+
+    /**
      * Value for operator date is after.
      */
     public const DATE_IS_AFTER = 1;

--- a/classes/local/tool_dynamic_cohorts/condition/fields_trait.php
+++ b/classes/local/tool_dynamic_cohorts/condition/fields_trait.php
@@ -42,6 +42,8 @@ trait fields_trait {
             self::TEXT_ENDS_WITH => get_string('endswith', 'filters'),
             self::TEXT_IS_EMPTY => get_string('isempty', 'filters'),
             self::TEXT_IS_NOT_EMPTY => get_string('isnotempty', 'tool_dynamic_cohorts'),
+            self::TEXT_IN => get_string('textin', 'tool_dynamic_cohorts'),
+            self::TEXT_NOT_IN => get_string('textnotin', 'tool_dynamic_cohorts'),
         ];
     }
 
@@ -340,11 +342,38 @@ trait fields_trait {
                 $where = $DB->sql_compare_text("$tablealias.$fieldname") . " != " . $DB->sql_compare_text(":$param");
                 $params[$param] = '';
                 break;
+            case self::TEXT_IN:
+                [$insql, $inparams] = $DB->get_in_or_equal(explode(', ', $fieldvalue), SQL_PARAMS_QM);
+                
+                foreach($inparams as $key => $val) {    
+                    $insql = $this->str_replace_first('?', ':'.$param, $insql);
+                    $params[$param] = $val;
+                    $param = condition_sql::generate_param_alias();
+                }
+                $where = $DB->sql_compare_text("$tablealias.$fieldname") . " " . $insql;
+                break;
+            case self::TEXT_NOT_IN:
+                [$insql, $inparams] = $DB->get_in_or_equal(explode(', ', $fieldvalue), SQL_PARAMS_QM, 'param', false);
+
+                foreach ($inparams as $key => $val) {
+                    $insql = $this->str_replace_first('?', ':' . $param, $insql);
+                    $params[$param] = $val;
+                    $param = condition_sql::generate_param_alias();
+                }
+                $where = $DB->sql_compare_text("$tablealias.$fieldname") . " " . $insql;
+                break;
             default:
                 return new condition_sql('', '', []);
         }
 
+        
         return new condition_sql('', $where, $params);
+    }
+
+    protected function str_replace_first($search, $replace, $subject)
+    {
+        $search = '/' . preg_quote($search, '/') . '/';
+        return preg_replace($search, $replace, $subject, 1);
     }
 
     /**

--- a/lang/en/tool_dynamic_cohorts.php
+++ b/lang/en/tool_dynamic_cohorts.php
@@ -165,3 +165,5 @@ $string['realtime'] = 'Real time processing';
 $string['realtime_help'] = 'If enabled, the rule will be processed synchronously as part of the event (if conditions support triggering on the event). Use caution when enabling as long running rule processing will block the user interface.';
 $string['rule_entity.realtime'] = 'Realtime processing';
 $string['realtimedisabledglobally'] = 'Realtime processing disabled globally';
+$string['textin'] = ' set to one of the values';
+$string['textnotin'] = 'not set to one of the values';


### PR DESCRIPTION
Hello everyone,

I am the developer of the SmartCohort plugin from CNW Co., a Moodle Partner. We have transitioned to Dynamic Cohort in our cloud service, and our goal is to assist you with our developments in the future.

One of our clients reported that they are unable to create a specific rule that was possible in SmartCohort. To enable this functionality, I have implemented the "IN" and "NOT IN" conditions. Currently, it simply separates the values with commas and applies the filtering accordingly.

Is there anything else we need to do to get this officially included?

You can add this condition:
![image](https://github.com/user-attachments/assets/9796e38e-cb74-40da-896a-b772e332bdc0)

Or this:
![image](https://github.com/user-attachments/assets/e1a4b358-b5d1-4814-9bdc-1d2f759e280b)

![image](https://github.com/user-attachments/assets/4a30c2c5-31e2-4fd1-8609-a2deb96fe5a0)
