### PR TITLE
issue #160: cast int for datetime custom profile field

### DIFF
--- a/classes/local/tool_dynamic_cohorts/condition/cohort_field.php
+++ b/classes/local/tool_dynamic_cohorts/condition/cohort_field.php
@@ -140,6 +140,7 @@ class cohort_field extends condition_base {
 
                 $shortname = self::CUSTOM_FIELD_PREFIX . $customfield->get('shortname');
                 $fields[$shortname] = new \stdClass();
+                $fields[$shortname]->id = $customfield->get('id');
                 $fields[$shortname]->name = $customfield->get_formatted_name();
                 $fields[$shortname]->shortname = $shortname;
                 $fields[$shortname]->datatype = $customfield->get('type');
@@ -368,7 +369,8 @@ class cohort_field extends condition_base {
 
         if (!$this->is_broken()) {
             $configuredfield = $this->get_field_name();
-            $datatype = $this->get_fields_info()[$configuredfield]->datatype;
+            $fieldinfo = $this->get_fields_info()[$configuredfield];
+            $datatype = $fieldinfo->datatype;
             $fieldstable = condition_sql::generate_table_alias();
 
             // For custom fields target DB column "value" is from {customfield_data}.
@@ -398,26 +400,23 @@ class cohort_field extends condition_base {
 
             if ($this->is_custom_field($configuredfield)) {
                 $cohorttbl = condition_sql::generate_table_alias();
-                $fieldtbl = condition_sql::generate_table_alias();
-                $fieldcategorytbl = condition_sql::generate_table_alias();
-                $shortnameparam = condition_sql::generate_param_alias();
+                $fieldidparam = condition_sql::generate_param_alias();
 
-                $params[$shortnameparam] = str_replace(self::CUSTOM_FIELD_PREFIX, '', $configuredfield);
+                $params[$fieldidparam] = $fieldinfo->id;
 
-                $cohortwhere = "$fieldcategorytbl.component = 'core_cohort'
-                                     AND $fieldcategorytbl.area = 'cohort'
-                                     AND $fieldtbl.shortname = :$shortnameparam
-                                     AND $fieldwhere";
+                $cohortwhere = $fieldwhere;
 
                 if ($this->should_include_missing_data()) {
                     $cohortwhere .= " OR $fieldstable.instanceid IS NULL";
                 }
 
+                // The subquery prevents sql_cast_char2int from running on text values stored by other fields in the same column.
                 $cohortsql = "SELECT $cohorttbl.id
                                 FROM {cohort} $cohorttbl
-                           LEFT JOIN {customfield_data} $fieldstable ON $fieldstable.instanceid = $cohorttbl.id
-                           LEFT JOIN {customfield_field} $fieldtbl ON $fieldstable.fieldid = $fieldtbl.id
-                           LEFT JOIN {customfield_category} $fieldcategorytbl ON $fieldcategorytbl.id = $fieldtbl.categoryid
+                           LEFT JOIN (SELECT {$fieldstable}.instanceid, {$fieldstable}.value
+                                        FROM {customfield_data} {$fieldstable}
+                                       WHERE {$fieldstable}.fieldid = :{$fieldidparam}) {$fieldstable}
+                                  ON {$fieldstable}.instanceid = {$cohorttbl}.id
                                      $fieldjoin
                                WHERE $cohortwhere";
             } else {

--- a/classes/local/tool_dynamic_cohorts/condition/fields_trait.php
+++ b/classes/local/tool_dynamic_cohorts/condition/fields_trait.php
@@ -390,6 +390,8 @@ trait fields_trait {
      * @return condition_sql
      */
     protected function get_date_sql(string $tablealias, string $fieldname): condition_sql {
+        global $DB;
+
         $fieldvalue = $this->get_field_value();
         $operatorvalue = $this->get_operator_value();
 
@@ -397,30 +399,33 @@ trait fields_trait {
             return new condition_sql('', '', []);
         }
 
+        // We have to cast field to int as data is stored in DB as text and we comparing it to integer.
+        $field = $DB->sql_cast_char2int("$tablealias.$fieldname", true);
         $param = condition_sql::generate_param_alias();
+
         switch ($operatorvalue) {
             case self::TEXT_IS_EMPTY:
-                $where = "$tablealias.$fieldname = :$param OR $tablealias.$fieldname IS NULL";
+                $where = "$field = :$param OR $tablealias.$fieldname IS NULL";
                 $params[$param] = 0;
                 break;
             case self::TEXT_IS_NOT_EMPTY:
-                $where = "$tablealias.$fieldname <> :$param";
+                $where = "$field <> :$param";
                 $params[$param] = (int) $fieldvalue;
                 break;
             case self::DATE_IS_BEFORE:
-                $where = "$tablealias.$fieldname <= :$param";
+                $where = "$field <= :$param";
                 $params[$param] = (int) $fieldvalue;
                 break;
             case self::DATE_IS_AFTER:
-                $where = "$tablealias.$fieldname >= :$param";
+                $where = "$field >= :$param";
                 $params[$param] = (int) $fieldvalue;
                 break;
             case self::DATE_IN_THE_FUTURE:
-                $where = "$tablealias.$fieldname >= :$param";
+                $where = "$field >= :$param";
                 $params[$param] = time();
                 break;
             case self::DATE_IN_THE_PAST:
-                $where = "$tablealias.$fieldname <= :$param";
+                $where = "$field <= :$param";
                 $params[$param] = time();
                 break;
             default:

--- a/classes/local/tool_dynamic_cohorts/condition/user_custom_profile.php
+++ b/classes/local/tool_dynamic_cohorts/condition/user_custom_profile.php
@@ -80,7 +80,7 @@ class user_custom_profile extends user_profile {
 
             $field = (object)array_intersect_key(
                 (array)$customfield->field,
-                ['shortname' => 1, 'name' => 1, 'datatype' => 1, 'param1' => 1]
+                ['id' => 1, 'shortname' => 1, 'name' => 1, 'datatype' => 1, 'param1' => 1]
             );
 
             switch ($field->datatype) {
@@ -186,7 +186,8 @@ class user_custom_profile extends user_profile {
         $result = new condition_sql('', '1=0', []);
 
         $configuredfield = $this->get_field_name();
-        $datatype = $this->get_fields_info()[$configuredfield]->datatype;
+        $fieldinfo = $this->get_fields_info()[$configuredfield];
+        $datatype = $fieldinfo->datatype;
         $ud = condition_sql::generate_table_alias();
 
         switch ($datatype) {
@@ -206,21 +207,18 @@ class user_custom_profile extends user_profile {
         }
 
         if (!empty($result->get_params())) {
-            $userinfofield = condition_sql::generate_table_alias();
             $userinfodata = condition_sql::generate_table_alias();
-
-            $shortnameparam = condition_sql::generate_param_alias();
+            $fieldidparam = condition_sql::generate_param_alias();
             $extrafields = "{$userinfodata}.data, {$userinfodata}.userid";
 
+            // The subquery prevents sql_cast_char2int from running on text values stored by other fields in the same column.
             $join = "LEFT JOIN (SELECT $extrafields
-                                 FROM {user_info_data} $userinfodata
-                                 JOIN {user_info_field} $userinfofield
-                                   ON ({$userinfofield}.id = {$userinfodata}.fieldid
-                                      AND {$userinfofield}.shortname = :{$shortnameparam})) $ud
-                           ON ({$ud}.userid = u.id)";
+                                  FROM {user_info_data} $userinfodata
+                                 WHERE {$userinfodata}.fieldid = :{$fieldidparam}) $ud
+                            ON ({$ud}.userid = u.id)";
 
             $params = $result->get_params();
-            $params[$shortnameparam] = str_replace(self::FIELD_PREFIX, '', $configuredfield);
+            $params[$fieldidparam] = $fieldinfo->id;
 
             $where = $result->get_where();
 

--- a/tests/local/tool_dynamic_cohorts/condition/cohort_field_test.php
+++ b/tests/local/tool_dynamic_cohorts/condition/cohort_field_test.php
@@ -529,6 +529,59 @@ final class cohort_field_test extends \advanced_testcase {
     }
 
     /**
+     * Test that custom field date comparisons use numeric ordering, not lexical string ordering.
+     */
+    public function test_get_sql_data_custom_field_date_comparison_is_numeric(): void {
+        global $DB;
+
+        if (!class_exists(\core_cohort\customfield\cohort_handler::class)) {
+            $this->markTestSkipped();
+        }
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        // Create a text field to cover sql_cast_char2int regressions.
+        $textfield = $this->create_cohort_custom_field('textfield', 'text');
+        $datefield = $this->create_cohort_custom_field('datefield', 'date');
+
+        // These specific values are taken from the original bug report (#160).
+        $lowerdate = 952899000;
+        $threshold = 1205280000;
+        $higherdate = 1205280000 + 86400;
+
+        $cohortbeforethreshold = $this->getDataGenerator()->create_cohort([
+            'customfield_' . $textfield->get('shortname') => 'Test value 1',
+            'customfield_' . $datefield->get('shortname') => $lowerdate,
+        ]);
+        $cohortafterthreshold = $this->getDataGenerator()->create_cohort([
+            'customfield_' . $textfield->get('shortname') => 'Test value 2',
+            'customfield_' . $datefield->get('shortname') => $higherdate,
+        ]);
+
+        $userbeforethreshold = $this->getDataGenerator()->create_user(['username' => 'datebeforethreshold']);
+        $userafterthreshold = $this->getDataGenerator()->create_user(['username' => 'dateafterthreshold']);
+        cohort_add_member($cohortbeforethreshold->id, $userbeforethreshold->id);
+        cohort_add_member($cohortafterthreshold->id, $userafterthreshold->id);
+
+        $datefieldname = cohort_field::CUSTOM_FIELD_PREFIX . $datefield->get('shortname');
+        $condition = $this->get_condition([
+            'cohort_field_operator' => cohort_field::OPERATOR_IS_MEMBER_OF,
+            'cohort_field_field' => $datefieldname,
+            $datefieldname . '_operator' => condition_base::DATE_IS_AFTER,
+            $datefieldname . '_value' => $threshold,
+        ]);
+
+        $result = $condition->get_sql();
+        $sql = "SELECT u.id FROM {user} u {$result->get_join()} WHERE {$result->get_where()}";
+        $users = $DB->get_records_sql($sql, $result->get_params());
+
+        $this->assertCount(1, $users);
+        $this->assertArrayHasKey($userafterthreshold->id, $users);
+        $this->assertArrayNotHasKey($userbeforethreshold->id, $users);
+    }
+
+    /**
      * Test events that the condition is listening to.
      */
     public function test_get_events(): void {

--- a/tests/local/tool_dynamic_cohorts/condition/user_custom_profile_test.php
+++ b/tests/local/tool_dynamic_cohorts/condition/user_custom_profile_test.php
@@ -218,7 +218,7 @@ final class user_custom_profile_test extends \advanced_testcase {
         profile_save_data((object)['id' => $user1->id, 'profile_field_' . $fieldtext1->shortname => 'User 1 Field 1']);
         profile_save_data((object)['id' => $user1->id, 'profile_field_' . $fieldtext2->shortname => 'Opt 1']);
         profile_save_data((object)['id' => $user1->id, 'profile_field_' . $fieldcheckbox->shortname => '1']);
-        profile_save_data((object)['id' => $user1->id, 'profile_field_' . $fielddate->shortname => $now - WEEKSECS]);
+        profile_save_data((object)['id' => $user1->id, 'profile_field_' . $fielddate->shortname => 951868800]);
 
         $user2 = $this->getDataGenerator()->create_user(['username' => 'user2']);
         profile_save_data((object)['id' => $user2->id, 'profile_field_' . $fieldtext1->shortname => 'User 2 Field 1']);

--- a/tests/local/tool_dynamic_cohorts/condition/user_custom_profile_test.php
+++ b/tests/local/tool_dynamic_cohorts/condition/user_custom_profile_test.php
@@ -71,7 +71,7 @@ final class user_custom_profile_test extends \advanced_testcase {
             $data->{$name} = $value;
         }
 
-        $DB->insert_record('user_info_field', $data);
+        $data->id = $DB->insert_record('user_info_field', $data);
 
         return $data;
     }
@@ -339,6 +339,50 @@ final class user_custom_profile_test extends \advanced_testcase {
         $users = $DB->get_records_sql($sql, $result->get_params());
         $this->assertCount(1, $users);
         $this->assertArrayHasKey($user1->id, $users);
+    }
+
+    /**
+     * Test that datetime comparisons use numeric ordering, not lexical string ordering.
+     */
+    public function test_get_sql_data_date_comparison_is_numeric(): void {
+        global $CFG, $DB;
+
+        $this->resetAfterTest();
+
+        require_once($CFG->dirroot . '/user/profile/lib.php');
+
+        // Create a text field to cover sql_cast_char2int regressions.
+        $textfield = $this->add_user_profile_field('field1', 'text');
+        $datefield = $this->add_user_profile_field('field4', 'datetime', ['param1' => 2000, 'param2' => 5000]);
+
+        // These specific values are taken from the original bug report (#160).
+        $lowerdate = 952899000;
+        $threshold = 1205280000;
+        $higherdate = 1205280000 + 86400;
+
+        $userbeforethreshold = $this->getDataGenerator()->create_user(['username' => 'userdatebeforethreshold']);
+        profile_save_data((object) ['id' => $userbeforethreshold->id, 'profile_field_' . $textfield->shortname => 'User 1 Field 1']);
+        profile_save_data((object) ['id' => $userbeforethreshold->id, 'profile_field_' . $datefield->shortname => $lowerdate]);
+
+        $userafterthreshold = $this->getDataGenerator()->create_user(['username' => 'userdateafterthreshold']);
+        profile_save_data((object) ['id' => $userafterthreshold->id, 'profile_field_' . $textfield->shortname => 'User 2 Field 1']);
+        profile_save_data((object) ['id' => $userafterthreshold->id, 'profile_field_' . $datefield->shortname => $higherdate]);
+
+        $fieldname = 'profile_field_' . $datefield->shortname;
+        $condition = $this->get_condition([
+            'profilefield' => $fieldname,
+            $fieldname . '_operator' => condition_base::DATE_IS_AFTER,
+            $fieldname . '_value' => $threshold,
+            'include_missing_data' => 0,
+        ]);
+
+        $result = $condition->get_sql();
+        $sql = "SELECT u.id FROM {user} u {$result->get_join()} WHERE {$result->get_where()}";
+        $users = $DB->get_records_sql($sql, $result->get_params());
+
+        $this->assertCount(1, $users);
+        $this->assertArrayHasKey($userafterthreshold->id, $users);
+        $this->assertArrayNotHasKey($userbeforethreshold->id, $users);
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_dynamic_cohorts';
-$plugin->release = 2026020201;
-$plugin->version = 2026020201;
+$plugin->release = 2026031300;
+$plugin->version = 2026031300;
 $plugin->requires = 2022112800;
 $plugin->supported = [404, 501];
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Fixes #160 

Field 'data' from 'user_info_data' table is of text type. However, when we compare it to a datetime custom field value, which is an integer, we could get unexpected results. This is because technically we are comparing two strings when we expect to be comparing integers.

The patch addresses this by casting the string to an integer for the datetime condition.

Strings 

```
moodle45=# SELECT '952899000' > '1205280000';
 ?column? 
----------
 t
(1 row)
```

Integers 

```
moodle45=# SELECT 952899000 > 1205280000;
 ?column? 
----------
 f
(1 row)

```
