### PR TITLE
Combine multiple joins into a single where clause

### DIFF
--- a/classes/condition_base.php
+++ b/classes/condition_base.php
@@ -270,4 +270,31 @@ abstract class condition_base {
      * @return bool
      */
     abstract public function is_broken(): bool;
+
+    /**
+     * Whether this condition can be merged with other instances of the same class.
+     *
+     * When multiple merge-capable conditions of the same class appear in an OR rule,
+     * condition_manager will call build_merged_sql() once for the group instead of
+     * generating separate JOINs for each instance, which avoids N-way cross-products.
+     *
+     * @return bool
+     */
+    public function can_merge(): bool {
+        return false;
+    }
+
+    /**
+     * Build a single optimised condition_sql for a group of same-class conditions.
+     *
+     * Only called when can_merge() returns true and the rule operator is OR.
+     * Subclasses that return true from can_merge() must override this method.
+     *
+     * @param static[] $instances Array of condition instances to merge.
+     * @param int $operator Rule logical operator (rule_manager::CONDITIONS_OPERATOR_*).
+     * @return condition_sql
+     */
+    public static function build_merged_sql(array $instances, int $operator): condition_sql {
+        throw new \coding_exception(get_class(reset($instances)) . ' must implement build_merged_sql().');
+    }
 }

--- a/classes/condition_manager.php
+++ b/classes/condition_manager.php
@@ -224,6 +224,8 @@ class condition_manager {
         $join = '';
         $params = [];
 
+        // Instantiate all conditions first, failing fast on any broken condition.
+        $instances = [];
         foreach ($conditions as $condition) {
             if (!$condition instanceof condition) {
                 continue;
@@ -235,22 +237,50 @@ class condition_manager {
                 return new condition_sql($join, '1=0', $params);
             }
 
-            $sqldata = $instance->get_sql();
+            $instances[] = $instance;
+        }
 
+        // Under OR rules, group same-class merge-capable instances together so they
+        // can be collapsed into a single optimised subquery instead of N JOINs.
+        $mergegroups = [];
+        $regularinstances = [];
+
+        foreach ($instances as $instance) {
+            if ($operator == rule_manager::CONDITIONS_OPERATOR_OR && $instance->can_merge()) {
+                $mergegroups[get_class($instance)][] = $instance;
+            } else {
+                $regularinstances[] = $instance;
+            }
+        }
+
+        // Helper to append one condition_sql to the running join/where/params.
+        $append = function (condition_sql $sqldata) use (&$join, &$where, &$params, $operator): void {
             if (!empty($sqldata->get_join())) {
                 $join .= ' ' . $sqldata->get_join();
             }
-
             if (!empty($sqldata->get_where())) {
                 if (!empty($where)) {
                     $where .= ' ' . rule_manager::get_logical_operator_text($operator);
                 }
                 $where .= ' (' . $sqldata->get_where() . ')';
             }
-
             if (!empty($sqldata->get_params())) {
                 $params += $sqldata->get_params();
             }
+        };
+
+        // Process merge groups (always at least 2 instances; singletons fall through to regular).
+        foreach ($mergegroups as $class => $groupinstances) {
+            if (count($groupinstances) === 1) {
+                $regularinstances[] = reset($groupinstances);
+            } else {
+                $append($class::build_merged_sql($groupinstances, $operator));
+            }
+        }
+
+        // Process remaining conditions individually.
+        foreach ($regularinstances as $instance) {
+            $append($instance->get_sql());
         }
 
         // If we have conditions let's wrap them all in one big condition.

--- a/classes/local/tool_dynamic_cohorts/condition/course_completed.php
+++ b/classes/local/tool_dynamic_cohorts/condition/course_completed.php
@@ -19,6 +19,7 @@ namespace tool_dynamic_cohorts\local\tool_dynamic_cohorts\condition;
 use completion_info;
 use tool_dynamic_cohorts\condition_base;
 use tool_dynamic_cohorts\condition_sql;
+use tool_dynamic_cohorts\rule_manager;
 
 defined('MOODLE_INTERNAL') || die;
 
@@ -217,6 +218,44 @@ class course_completed extends condition_base {
         }
 
         return $sql;
+    }
+
+    /**
+     * Whether this condition can be merged with other course_completed conditions.
+     *
+     * Only OPERATOR_ANY conditions can be merged; date-bounded conditions carry
+     * per-course timestamps that must remain separate.
+     *
+     * @return bool
+     */
+    public function can_merge(): bool {
+        return !$this->is_broken() && $this->get_operator_value() === self::OPERATOR_ANY;
+    }
+
+    /**
+     * Build a single EXISTS subquery covering all merged OPERATOR_ANY instances.
+     *
+     * Replaces N separate JOINs (which produce an N-way cross-product) with one
+     * correlated EXISTS containing an IN() list. Only called for OR rules.
+     *
+     * @param static[] $instances Array of course_completed instances to merge.
+     * @param int $operator Rule logical operator.
+     * @return condition_sql
+     */
+    public static function build_merged_sql(array $instances, int $operator): condition_sql {
+        global $DB;
+
+        if ($operator != rule_manager::CONDITIONS_OPERATOR_OR || empty($instances)) {
+            return new condition_sql('', '1=0', []);
+        }
+
+        $courseids = array_map(fn($instance) => $instance->get_courseid_value(), array_values($instances));
+        [$insql, $params] = $DB->get_in_or_equal($courseids, SQL_PARAMS_NAMED, condition_sql::generate_param_alias());
+
+        $where = "EXISTS (SELECT 1 FROM {course_completions}"
+            . " WHERE userid = u.id AND course $insql AND timecompleted IS NOT NULL)";
+
+        return new condition_sql('', $where, $params);
     }
 
     /**

--- a/tests/condition_manager_test.php
+++ b/tests/condition_manager_test.php
@@ -21,6 +21,7 @@ use tool_dynamic_cohorts\event\condition_created;
 use tool_dynamic_cohorts\event\condition_deleted;
 use tool_dynamic_cohorts\event\condition_updated;
 use tool_dynamic_cohorts\local\tool_dynamic_cohorts\condition\course_completed;
+use tool_dynamic_cohorts\local\tool_dynamic_cohorts\condition\course_not_completed;
 use tool_dynamic_cohorts\local\tool_dynamic_cohorts\condition\user_profile;
 
 /**
@@ -553,5 +554,83 @@ final class condition_manager_test extends \advanced_testcase {
         // The two OPERATOR_ANY conditions are merged (EXISTS); OPERATOR_BEFORE keeps its JOIN.
         $this->assertStringContainsStringIgnoringCase('EXISTS', $sql->get_where());
         $this->assertNotEmpty($sql->get_join(), 'OPERATOR_BEFORE condition should still produce a JOIN');
+    }
+
+    /**
+     * Helper to create and save a course_not_completed condition record.
+     *
+     * @param rule $rule
+     * @param int $courseid
+     * @return condition
+     */
+    protected function make_course_not_completed_condition(rule $rule, int $courseid): condition {
+        $instance = course_not_completed::get_instance(0, (object)['ruleid' => $rule->get('id'), 'sortorder' => 1]);
+        $instance->set_config_data(['courseid' => $courseid, 'timecompleted' => 0]);
+        $instance->get_record()->save();
+        return $instance->get_record();
+    }
+
+    /**
+     * Multiple course_not_completed conditions under OR must not be merged.
+     *
+     * course_not_completed uses NOT-completed semantics (LEFT JOIN / IS NULL); merging
+     * them into a single EXISTS ... IN would invert the logic and return wrong results.
+     * This test verifies the SQL is correct and that build_sql_data() does not crash.
+     */
+    public function test_build_sql_data_does_not_merge_course_not_completed_under_or(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        $now = time();
+        $studentrole = $DB->get_record('role', ['shortname' => 'student']);
+        $cohort = $this->getDataGenerator()->create_cohort();
+
+        $rule = new rule(0, (object)[
+            'name'     => 'Not-completed OR rule',
+            'cohortid' => $cohort->id,
+            'operator' => rule_manager::CONDITIONS_OPERATOR_OR,
+        ]);
+        $rule->save();
+
+        $course1 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $course2 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+
+        // user1 completed course1 (so has NOT completed course2).
+        // user2 completed neither course.
+        // user3 completed both courses.
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+        $user3 = $this->getDataGenerator()->create_user();
+
+        foreach ([$user1, $user3] as $user) {
+            $this->getDataGenerator()->enrol_user($user->id, $course1->id, $studentrole->id);
+        }
+        foreach ([$user1, $user2, $user3] as $user) {
+            $this->getDataGenerator()->enrol_user($user->id, $course2->id, $studentrole->id);
+        }
+
+        (new \completion_completion(['userid' => $user1->id, 'course' => $course1->id]))->mark_complete($now);
+        (new \completion_completion(['userid' => $user3->id, 'course' => $course1->id]))->mark_complete($now);
+        (new \completion_completion(['userid' => $user3->id, 'course' => $course2->id]))->mark_complete($now);
+
+        $conditions = [
+            $this->make_course_not_completed_condition($rule, $course1->id),
+            $this->make_course_not_completed_condition($rule, $course2->id),
+        ];
+
+        // Must not crash (previously would throw coding_exception via incorrect merge).
+        $sql = condition_manager::build_sql_data($conditions, rule_manager::CONDITIONS_OPERATOR_OR);
+
+        // Should not use EXISTS — course_not_completed relies on LEFT JOIN / IS NULL.
+        $this->assertStringNotContainsStringIgnoringCase('EXISTS', $sql->get_where());
+
+        // Correctness: user1 has not completed course2, user2 has not completed either
+        // course, user3 has completed both so should be excluded.
+        $basesql = "SELECT DISTINCT u.id FROM {user} u {$sql->get_join()} WHERE {$sql->get_where()}";
+        $rows = $DB->get_records_sql($basesql, $sql->get_params());
+        $this->assertArrayHasKey($user1->id, $rows, 'user1 has not completed course2 so should match');
+        $this->assertArrayHasKey($user2->id, $rows, 'user2 has not completed either course so should match');
+        $this->assertArrayNotHasKey($user3->id, $rows, 'user3 completed both courses so should not match');
     }
 }

--- a/tests/condition_manager_test.php
+++ b/tests/condition_manager_test.php
@@ -20,6 +20,7 @@ use core\event\user_created;
 use tool_dynamic_cohorts\event\condition_created;
 use tool_dynamic_cohorts\event\condition_deleted;
 use tool_dynamic_cohorts\event\condition_updated;
+use tool_dynamic_cohorts\local\tool_dynamic_cohorts\condition\course_completed;
 use tool_dynamic_cohorts\local\tool_dynamic_cohorts\condition\user_profile;
 
 /**
@@ -331,5 +332,226 @@ final class condition_manager_test extends \advanced_testcase {
         $this->assertCount(2, $DB->get_records_sql($sqlor, $sqldataor->get_params()));
         $this->assertArrayNotHasKey($usertodeleted->id, $DB->get_records_sql($sqland, $sqldataand->get_params()));
         $this->assertArrayNotHasKey($usertodeleted->id, $DB->get_records_sql($sqlor, $sqldataor->get_params()));
+    }
+
+    /**
+     * Helper to create and save a course_completed condition record for build_sql_data tests.
+     *
+     * @param rule $rule
+     * @param int $courseid
+     * @param int $operator
+     * @param int $timecompleted
+     * @return condition
+     */
+    protected function make_course_completed_condition(
+        rule $rule,
+        int $courseid,
+        int $operator = course_completed::OPERATOR_ANY,
+        int $timecompleted = 0
+    ): condition {
+        $instance = course_completed::get_instance(0, (object)['ruleid' => $rule->get('id'), 'sortorder' => 1]);
+        $instance->set_config_data([
+            'courseid'      => $courseid,
+            'operator'      => $operator,
+            'timecompleted' => $timecompleted,
+        ]);
+        $instance->get_record()->save();
+        return $instance->get_record();
+    }
+
+    /**
+     * Multiple OPERATOR_ANY course_completed conditions under OR are merged into a single
+     * EXISTS subquery — no cross-product JOINs.
+     */
+    public function test_build_sql_data_merges_course_completed_under_or(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        $now = time();
+        $studentrole = $DB->get_record('role', ['shortname' => 'student']);
+        $cohort = $this->getDataGenerator()->create_cohort();
+
+        $rule = new rule(0, (object)[
+            'name'     => 'Merge OR rule',
+            'cohortid' => $cohort->id,
+            'operator' => rule_manager::CONDITIONS_OPERATOR_OR,
+        ]);
+        $rule->save();
+
+        $course1 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $course2 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $course3 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+
+        // user1 completed course1, user2 completed course2, user3 completed none.
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+        $user3 = $this->getDataGenerator()->create_user();
+
+        $this->getDataGenerator()->enrol_user($user1->id, $course1->id, $studentrole->id);
+        $this->getDataGenerator()->enrol_user($user2->id, $course2->id, $studentrole->id);
+
+        (new \completion_completion(['userid' => $user1->id, 'course' => $course1->id]))->mark_complete($now);
+        (new \completion_completion(['userid' => $user2->id, 'course' => $course2->id]))->mark_complete($now);
+
+        $conditions = [
+            $this->make_course_completed_condition($rule, $course1->id),
+            $this->make_course_completed_condition($rule, $course2->id),
+            $this->make_course_completed_condition($rule, $course3->id),
+        ];
+
+        $sql = condition_manager::build_sql_data($conditions, rule_manager::CONDITIONS_OPERATOR_OR);
+
+        // Merged path: no JOINs, a single EXISTS in the WHERE.
+        $this->assertEmpty($sql->get_join(), 'Merged OR conditions should produce no JOINs');
+        $this->assertStringContainsStringIgnoringCase('EXISTS', $sql->get_where());
+
+        // Correctness: user1 and user2 match (any completion), user3 does not.
+        $basesql = "SELECT DISTINCT u.id FROM {user} u {$sql->get_join()} WHERE {$sql->get_where()}";
+        $rows = $DB->get_records_sql($basesql, $sql->get_params());
+        $this->assertArrayHasKey($user1->id, $rows);
+        $this->assertArrayHasKey($user2->id, $rows);
+        $this->assertArrayNotHasKey($user3->id, $rows);
+    }
+
+    /**
+     * Multiple course_completed conditions under AND are NOT merged — each requires its
+     * own JOIN to enforce that the user completed every listed course.
+     */
+    public function test_build_sql_data_does_not_merge_course_completed_under_and(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        $now = time();
+        $studentrole = $DB->get_record('role', ['shortname' => 'student']);
+        $cohort = $this->getDataGenerator()->create_cohort();
+
+        $rule = new rule(0, (object)[
+            'name'     => 'No-merge AND rule',
+            'cohortid' => $cohort->id,
+            'operator' => rule_manager::CONDITIONS_OPERATOR_AND,
+        ]);
+        $rule->save();
+
+        $course1 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $course2 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+
+        // user1 completed both courses, user2 completed only course1.
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+
+        $this->getDataGenerator()->enrol_user($user1->id, $course1->id, $studentrole->id);
+        $this->getDataGenerator()->enrol_user($user1->id, $course2->id, $studentrole->id);
+        $this->getDataGenerator()->enrol_user($user2->id, $course1->id, $studentrole->id);
+
+        (new \completion_completion(['userid' => $user1->id, 'course' => $course1->id]))->mark_complete($now);
+        (new \completion_completion(['userid' => $user1->id, 'course' => $course2->id]))->mark_complete($now);
+        (new \completion_completion(['userid' => $user2->id, 'course' => $course1->id]))->mark_complete($now);
+
+        $conditions = [
+            $this->make_course_completed_condition($rule, $course1->id),
+            $this->make_course_completed_condition($rule, $course2->id),
+        ];
+
+        $sql = condition_manager::build_sql_data($conditions, rule_manager::CONDITIONS_OPERATOR_AND);
+
+        // AND path: separate JOINs retained, no EXISTS.
+        $this->assertNotEmpty($sql->get_join(), 'AND conditions should still use JOINs');
+        $this->assertStringNotContainsStringIgnoringCase('EXISTS', $sql->get_where());
+
+        // Correctness: only user1 completed both courses.
+        $basesql = "SELECT DISTINCT u.id FROM {user} u {$sql->get_join()} WHERE {$sql->get_where()}";
+        $rows = $DB->get_records_sql($basesql, $sql->get_params());
+        $this->assertArrayHasKey($user1->id, $rows);
+        $this->assertArrayNotHasKey($user2->id, $rows);
+    }
+
+    /**
+     * A single course_completed condition under OR is not merged (no benefit) and falls
+     * back to the regular JOIN path.
+     */
+    public function test_build_sql_data_singleton_course_completed_uses_join(): void {
+        $this->resetAfterTest();
+
+        $cohort = $this->getDataGenerator()->create_cohort();
+        $rule = new rule(0, (object)[
+            'name'     => 'Singleton OR rule',
+            'cohortid' => $cohort->id,
+            'operator' => rule_manager::CONDITIONS_OPERATOR_OR,
+        ]);
+        $rule->save();
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $conditions = [$this->make_course_completed_condition($rule, $course->id)];
+
+        $sql = condition_manager::build_sql_data($conditions, rule_manager::CONDITIONS_OPERATOR_OR);
+
+        // Singleton falls back to regular get_sql() which uses a JOIN, not EXISTS.
+        $this->assertNotEmpty($sql->get_join());
+        $this->assertStringNotContainsStringIgnoringCase('EXISTS', $sql->get_where());
+    }
+
+    /**
+     * Date-bounded (OPERATOR_BEFORE/AFTER) course_completed conditions are not merged
+     * even under OR — they stay as individual JOINs.
+     */
+    public function test_build_sql_data_does_not_merge_date_bounded_conditions(): void {
+        $this->resetAfterTest();
+
+        $cohort = $this->getDataGenerator()->create_cohort();
+        $rule = new rule(0, (object)[
+            'name'     => 'Date-bounded OR rule',
+            'cohortid' => $cohort->id,
+            'operator' => rule_manager::CONDITIONS_OPERATOR_OR,
+        ]);
+        $rule->save();
+
+        $course1 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $course2 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+
+        $conditions = [
+            $this->make_course_completed_condition($rule, $course1->id, course_completed::OPERATOR_BEFORE, time()),
+            $this->make_course_completed_condition($rule, $course2->id, course_completed::OPERATOR_AFTER, time()),
+        ];
+
+        $sql = condition_manager::build_sql_data($conditions, rule_manager::CONDITIONS_OPERATOR_OR);
+
+        // Date-bounded conditions cannot be merged — each uses its own JOIN.
+        $this->assertNotEmpty($sql->get_join());
+        $this->assertStringNotContainsStringIgnoringCase('EXISTS', $sql->get_where());
+        $this->assertStringContainsString('OR', $sql->get_where());
+    }
+
+    /**
+     * Mixed OPERATOR_ANY (mergeable) and OPERATOR_BEFORE (not mergeable) conditions
+     * under OR: the ANY group is merged into EXISTS; the BEFORE stays as a JOIN.
+     */
+    public function test_build_sql_data_mixed_mergeable_and_date_bounded(): void {
+        $this->resetAfterTest();
+
+        $cohort = $this->getDataGenerator()->create_cohort();
+        $rule = new rule(0, (object)[
+            'name'     => 'Mixed OR rule',
+            'cohortid' => $cohort->id,
+            'operator' => rule_manager::CONDITIONS_OPERATOR_OR,
+        ]);
+        $rule->save();
+
+        $course1 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $course2 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $course3 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+
+        $conditions = [
+            $this->make_course_completed_condition($rule, $course1->id),
+            $this->make_course_completed_condition($rule, $course2->id),
+            $this->make_course_completed_condition($rule, $course3->id, course_completed::OPERATOR_BEFORE, time()),
+        ];
+
+        $sql = condition_manager::build_sql_data($conditions, rule_manager::CONDITIONS_OPERATOR_OR);
+
+        // The two OPERATOR_ANY conditions are merged (EXISTS); OPERATOR_BEFORE keeps its JOIN.
+        $this->assertStringContainsStringIgnoringCase('EXISTS', $sql->get_where());
+        $this->assertNotEmpty($sql->get_join(), 'OPERATOR_BEFORE condition should still produce a JOIN');
     }
 }

--- a/tests/local/tool_dynamic_cohorts/condition/course_completed_test.php
+++ b/tests/local/tool_dynamic_cohorts/condition/course_completed_test.php
@@ -18,6 +18,7 @@ namespace tool_dynamic_cohorts\local\tool_dynamic_cohorts\condition;
 
 use tool_dynamic_cohorts\condition_base;
 use tool_dynamic_cohorts\rule;
+use tool_dynamic_cohorts\rule_manager;
 
 /**
  * Unit tests for course_completed condition class.
@@ -261,5 +262,154 @@ final class course_completed_test extends \advanced_testcase {
      */
     public function test_get_events(): void {
         $this->assertEquals([], $this->get_condition()->get_events());
+    }
+
+    /**
+     * Test can_merge() returns true only for OPERATOR_ANY on non-broken conditions.
+     */
+    public function test_can_merge(): void {
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+
+        // OPERATOR_ANY on a valid course: mergeable.
+        $condition = $this->get_condition([
+            'courseid' => $course->id,
+            'operator' => course_completed::OPERATOR_ANY,
+            'timecompleted' => 0,
+        ]);
+        $this->assertTrue($condition->can_merge());
+
+        // OPERATOR_BEFORE: not mergeable (date-bounded).
+        $condition = $this->get_condition([
+            'courseid' => $course->id,
+            'operator' => course_completed::OPERATOR_BEFORE,
+            'timecompleted' => time(),
+        ]);
+        $this->assertFalse($condition->can_merge());
+
+        // OPERATOR_AFTER: not mergeable (date-bounded).
+        $condition = $this->get_condition([
+            'courseid' => $course->id,
+            'operator' => course_completed::OPERATOR_AFTER,
+            'timecompleted' => time(),
+        ]);
+        $this->assertFalse($condition->can_merge());
+
+        // Broken condition (non-existent course): not mergeable.
+        $condition = $this->get_condition([
+            'courseid' => 99999,
+            'operator' => course_completed::OPERATOR_ANY,
+            'timecompleted' => 0,
+        ]);
+        $this->assertFalse($condition->can_merge());
+    }
+
+    /**
+     * Test build_merged_sql() returns a 1=0 fallback for AND operator or empty input.
+     */
+    public function test_build_merged_sql_returns_fallback_for_non_or_operators(): void {
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $inst = $this->get_condition([
+            'courseid' => $course->id,
+            'operator' => course_completed::OPERATOR_ANY,
+            'timecompleted' => 0,
+        ]);
+
+        // AND operator: not supported, returns 1=0.
+        $result = course_completed::build_merged_sql([$inst], rule_manager::CONDITIONS_OPERATOR_AND);
+        $this->assertEmpty($result->get_join());
+        $this->assertSame('1=0', $result->get_where());
+        $this->assertEmpty($result->get_params());
+
+        // Empty instances array: returns 1=0.
+        $result = course_completed::build_merged_sql([], rule_manager::CONDITIONS_OPERATOR_OR);
+        $this->assertEmpty($result->get_join());
+        $this->assertSame('1=0', $result->get_where());
+        $this->assertEmpty($result->get_params());
+    }
+
+    /**
+     * Test build_merged_sql() produces an EXISTS subquery with an IN list for OR rules.
+     */
+    public function test_build_merged_sql_uses_exists_with_in(): void {
+        $this->resetAfterTest();
+
+        $course1 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $course2 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+
+        $inst1 = $this->get_condition([
+            'courseid' => $course1->id,
+            'operator' => course_completed::OPERATOR_ANY,
+            'timecompleted' => 0,
+        ]);
+        $inst2 = $this->get_condition([
+            'courseid' => $course2->id,
+            'operator' => course_completed::OPERATOR_ANY,
+            'timecompleted' => 0,
+        ]);
+
+        $result = course_completed::build_merged_sql([$inst1, $inst2], rule_manager::CONDITIONS_OPERATOR_OR);
+
+        // No JOIN — all filtering is in the EXISTS subquery.
+        $this->assertEmpty($result->get_join());
+
+        // WHERE uses EXISTS … IN.
+        $where = $result->get_where();
+        $this->assertStringContainsStringIgnoringCase('EXISTS', $where);
+        $this->assertStringContainsStringIgnoringCase('IN', $where);
+        $this->assertStringContainsString('timecompleted IS NOT NULL', $where);
+
+        // Both course IDs appear in the parameter list.
+        $params = $result->get_params();
+        $this->assertNotEmpty($params);
+        $this->assertContainsEquals($course1->id, $params);
+        $this->assertContainsEquals($course2->id, $params);
+    }
+
+    /**
+     * Test build_merged_sql() returns the correct set of users from the database.
+     */
+    public function test_build_merged_sql_returns_correct_users(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        $now = time();
+        $studentrole = $DB->get_record('role', ['shortname' => 'student']);
+
+        $course1 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $course2 = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+
+        $user1 = $this->getDataGenerator()->create_user(); // completes course1 only
+        $user2 = $this->getDataGenerator()->create_user(); // completes course2 only
+        $user3 = $this->getDataGenerator()->create_user(); // completes neither
+
+        $this->getDataGenerator()->enrol_user($user1->id, $course1->id, $studentrole->id);
+        $this->getDataGenerator()->enrol_user($user2->id, $course2->id, $studentrole->id);
+
+        (new \completion_completion(['userid' => $user1->id, 'course' => $course1->id]))->mark_complete($now);
+        (new \completion_completion(['userid' => $user2->id, 'course' => $course2->id]))->mark_complete($now);
+
+        $inst1 = $this->get_condition([
+            'courseid' => $course1->id,
+            'operator' => course_completed::OPERATOR_ANY,
+            'timecompleted' => 0,
+        ]);
+        $inst2 = $this->get_condition([
+            'courseid' => $course2->id,
+            'operator' => course_completed::OPERATOR_ANY,
+            'timecompleted' => 0,
+        ]);
+
+        $result = course_completed::build_merged_sql([$inst1, $inst2], rule_manager::CONDITIONS_OPERATOR_OR);
+        $sql = "SELECT u.id FROM {user} u {$result->get_join()} WHERE {$result->get_where()}";
+        $rows = $DB->get_records_sql($sql, $result->get_params());
+
+        $this->assertArrayHasKey($user1->id, $rows, 'User who completed course1 should be included');
+        $this->assertArrayHasKey($user2->id, $rows, 'User who completed course2 should be included');
+        $this->assertArrayNotHasKey($user3->id, $rows, 'User with no completions should be excluded');
     }
 }

--- a/tests/local/tool_dynamic_cohorts/condition/course_not_completed_test.php
+++ b/tests/local/tool_dynamic_cohorts/condition/course_not_completed_test.php
@@ -202,4 +202,23 @@ final class course_not_completed_test extends \advanced_testcase {
     public function test_get_events(): void {
         $this->assertEquals([], $this->get_condition()->get_events());
     }
+
+    /**
+     * Test that course_not_completed can never be merged, even when non-broken.
+     *
+     * course_not_completed extends course_completed but uses NOT-completed semantics;
+     * merging multiple NOT-completed conditions under OR would produce incorrect SQL.
+     */
+    public function test_cannot_merge(): void {
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+
+        $condition = $this->get_condition([
+            'courseid'      => $course->id,
+            'timecompleted' => 0,
+        ]);
+
+        $this->assertFalse($condition->can_merge());
+    }
 }


### PR DESCRIPTION
In prod we had a site with poor performance, with this sql:

```
SELECT COUNT(DISTINCT u.id) cnt
   FROM mdl_user u
   JOIN mdl_course_completions rbalias1000 ON (rbalias1000.userid = u.id)
   JOIN mdl_course_completions rbalias1001 ON (rbalias1001.userid = u.id)
   JOIN mdl_course_completions rbalias1002 ON (rbalias1002.userid = u.id)
   JOIN mdl_course_completions rbalias1003 ON (rbalias1003.userid = u.id)
   WHERE (
       (rbalias1000.course = $1 AND rbalias1000.timecompleted IS NOT NULL)
    OR (rbalias1001.course = $2 AND rbalias1001.timecompleted IS NOT NULL)
    OR (rbalias1002.course = $3 AND rbalias1002.timecompleted IS NOT NULL)
    OR (rbalias1003.course = $4 AND rbalias1003.timecompleted IS NOT NULL)
   )
   AND (u.deleted = 0)
```

This was producing an explain plan with a cost of:

```
Limit (cost=9931067.79..9931067.80 rows=1 width=8)
```

this patch detects cases when there is multiple conditions which would have previously turned into multiple joins and combines them into one join:

```
SELECT COUNT(DISTINCT u.id) cnt
   FROM mdl_user u
   WHERE (
       EXISTS (
           SELECT 1 FROM mdl_course_completions
           WHERE userid = u.id
             AND course IN ($1, $2, $3, $4)
             AND timecompleted IS NOT NULL
       )
   )
   AND (u.deleted = 0)

```

This has an explain plan cost of:

```
Limit (cost=98.14..98.15 rows=1 width=8)
```

