### PR TITLE
issue #182: invalidate stale matching users count cache

### DIFF
--- a/classes/rule_manager.php
+++ b/classes/rule_manager.php
@@ -248,6 +248,8 @@ class rule_manager {
             $users = $DB->get_records_sql($sql . $sqldata->get_join() . ' WHERE ' . $sqldata->get_where(), $sqldata->get_params());
             if (empty($userid)) {
                 $matchinguserscache->set($rule->get('id'), count($users));
+            } else {
+                $matchinguserscache->delete($rule->get('id'));
             }
             return $users;
         } catch (\Exception $exception) {

--- a/tests/rule_manager_test.php
+++ b/tests/rule_manager_test.php
@@ -944,6 +944,79 @@ final class rule_manager_test extends \advanced_testcase {
     }
 
     /**
+     * Data provider for testing targeted rule processing invalidates the matching users count cache.
+     *
+     * @return array
+     */
+    public static function targeted_rule_processing_provider(): array {
+        return [
+            'matching to non-matching' => ['matchingusername', 'otherusername', 1, 0],
+            'non-matching to matching' => ['otherusername', 'matchingusername', 0, 1],
+        ];
+    }
+
+    /**
+     * Test targeted rule processing invalidates the matching users count cache.
+     *
+     * @dataProvider targeted_rule_processing_provider
+     * @param string $initialusername Initial username.
+     * @param string $updatedusername Updated username.
+     * @param int $initialcount Initial matching user count.
+     * @param int $updatedcount Updated matching user count.
+     */
+    public function test_targeted_rule_processing_invalidates_matching_users_count_cache(
+        string $initialusername,
+        string $updatedusername,
+        int $initialcount,
+        int $updatedcount
+    ): void {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        $user = $this->getDataGenerator()->create_user(['username' => $initialusername]);
+        $cohort = $this->getDataGenerator()->create_cohort();
+
+        $rule = new rule(0, (object)[
+            'name' => 'Test rule',
+            'cohortid' => $cohort->id,
+            'enabled' => 1,
+            'realtime' => 1,
+        ]);
+        $rule->save();
+
+        $condition = user_profile::get_instance(0, (object)['ruleid' => $rule->get('id'), 'sortorder' => 1]);
+        $condition->set_config_data([
+            'profilefield' => 'username',
+            'username_operator' => condition_base::TEXT_IS_EQUAL_TO,
+            'username_value' => 'matchingusername',
+        ]);
+        $condition->get_record()->save();
+
+        rule_manager::process_rule($rule);
+
+        $cache = cache::make('tool_dynamic_cohorts', 'matchinguserscount');
+        $cache->delete($rule->get('id'));
+        $this->assertSame($initialcount, rule_manager::get_matching_users_count($rule));
+        $this->assertSame($initialcount, (int) $cache->get($rule->get('id')));
+        $this->assertSame(
+            (bool) $initialcount,
+            $DB->record_exists('cohort_members', ['cohortid' => $cohort->id, 'userid' => $user->id])
+        );
+
+        $DB->set_field('user', 'username', $updatedusername, ['id' => $user->id]);
+        rule_manager::process_rule($rule, $user->id);
+
+        $this->assertSame(
+            (bool) $updatedcount,
+            $DB->record_exists('cohort_members', ['cohortid' => $cohort->id, 'userid' => $user->id])
+        );
+        $this->assertFalse($cache->get($rule->get('id')));
+        $this->assertSame($updatedcount, rule_manager::get_matching_users_count($rule));
+        $this->assertSame($updatedcount, (int) $cache->get($rule->get('id')));
+    }
+
+    /**
      * Test that a list of matching users is cached.
      */
     public function test_matching_users_get_cached(): void {

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_dynamic_cohorts';
-$plugin->release = 2026031301;
-$plugin->version = 2026031301;
+$plugin->release = 2026031302;
+$plugin->version = 2026031302;
 $plugin->requires = 2022112800;
 $plugin->supported = [404, 501];
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
### Summary

Fixes #182.

Realtime rule processing can correctly update cohort membership while
leaving the cached global matching-users count stale.

Targeted processing calls:

`rule_manager::get_matching_users($rule, $userid)`

but previously did not update or invalidate the global
`matchinguserscount` cache entry.

### Fix

Invalidate the rule's matching-users count cache after a successful
targeted lookup.

Full matching-user lookups retain the existing behaviour and cache the
authoritative count.

This avoids performing a full count during realtime processing while
ensuring the next count request recalculates the correct value.

### Tests

Added a regression test covering both transitions:

- matching → non-matching
- non-matching → matching

Local verification:

- focused regression test: 2 tests, 14 assertions — passed
- `rule_manager_test.php`: 36 tests, 233 assertions — passed
- PHP lint — passed
- `git diff --check` — passed

The issue was also reproduced and the fix manually validated using
realtime profile updates on Moodle 5.2.2.